### PR TITLE
fix: グループで翻訳言語を取得できなかった場合のメッセージ出力を誤って消したので、復活

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -192,10 +192,13 @@ async function handleTextEvent(args: {
   // 翻訳言語の取得
   let targetLanguageCode: string;
   if (args.sourceGroupId) {
-    targetLanguageCode =
-      (await getLanguageCodeByGroupId(args.sourceGroupId)) ||
-      process.env.TARGET_LANG_CODE_DEFAULT ||
-      'en-US';
+    const langCodeFromDB = await getLanguageCodeByGroupId(args.sourceGroupId);
+    if (!langCodeFromDB) {
+      replyText += `[Warn] No target language is set for the group. Please set a target language by sending a message "@koto-hashi 〇〇語を登録" in the group.\n\n`;
+      targetLanguageCode = process.env.TARGET_LANG_CODE_DEFAULT || 'en-US';
+    } else {
+      targetLanguageCode = langCodeFromDB;
+    }
   } else {
     // グループIDが取得できない場合は、環境変数のデフォルト値を使用する
     targetLanguageCode = process.env.TARGET_LANG_CODE_DEFAULT || 'en-US';


### PR DESCRIPTION
This pull request improves user feedback when a target language is not set for a group in the `handleTextEvent` function. Now, if no language is configured, the bot notifies the user with a warning message and falls back to the default language.

User experience improvements:

* Added a warning message to `replyText` when no target language is set for the group, instructing users how to set it, and ensured the default language code is used as a fallback.