### PR TITLE
change: GeminiのThinkingLevelの見直し

### DIFF
--- a/src/langDetector.ts
+++ b/src/langDetector.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI } from '@google/genai';
+import { GoogleGenAI, ThinkingLevel } from '@google/genai';
 import { z } from 'zod';
 import fs from 'fs';
 import path from 'path';
@@ -73,6 +73,9 @@ export async function detectTargetLanguage(
       responseMimeType: 'application/json',
       responseJsonSchema: z.toJSONSchema(DetectionResultSchema),
       temperature: 0.1,
+      thinkingConfig: {
+        thinkingLevel: ThinkingLevel.MINIMAL,
+      },
       systemInstruction: systemPrompt,
     },
   });

--- a/src/translator.ts
+++ b/src/translator.ts
@@ -1,4 +1,4 @@
-import { GoogleGenAI } from '@google/genai';
+import { GoogleGenAI, ThinkingLevel } from '@google/genai';
 import { z } from 'zod';
 import fs from 'fs';
 import path from 'path';
@@ -62,6 +62,9 @@ export async function translateText(
       responseMimeType: 'application/json',
       responseJsonSchema: z.toJSONSchema(translationResultSchema),
       temperature: 0.1,
+      thinkingConfig: {
+        thinkingLevel: ThinkingLevel.LOW,
+      },
       systemInstruction: systemPrompt.replaceAll('{lang}', targetLanguageCode),
     },
   });


### PR DESCRIPTION
Closes: #25 

This pull request updates the language detection and translation modules to use the new `ThinkingLevel` configuration from the `@google/genai` package. This allows for finer control over the model's reasoning depth during language detection and translation tasks.

Integration of `ThinkingLevel` configuration:

* [`src/langDetector.ts`](diffhunk://#diff-3fb026ba65309e9726bc580e2d76e4d95e21a411e90e39e532b4e29ee89773b3L1-R1): Imports `ThinkingLevel` from `@google/genai` and sets `thinkingLevel` to `MINIMAL` in the `thinkingConfig` for the language detection request, aiming for faster and more concise responses. [[1]](diffhunk://#diff-3fb026ba65309e9726bc580e2d76e4d95e21a411e90e39e532b4e29ee89773b3L1-R1) [[2]](diffhunk://#diff-3fb026ba65309e9726bc580e2d76e4d95e21a411e90e39e532b4e29ee89773b3R76-R78)
* [`src/translator.ts`](diffhunk://#diff-4cf5660e3c535a735b6953d578a91b9ce1dd14b064f584d2f3e58cd3264627dbL1-R1): Imports `ThinkingLevel` from `@google/genai` and sets `thinkingLevel` to `LOW` in the `thinkingConfig` for the translation request, allowing for a slightly higher reasoning level during translation. [[1]](diffhunk://#diff-4cf5660e3c535a735b6953d578a91b9ce1dd14b064f584d2f3e58cd3264627dbL1-R1) [[2]](diffhunk://#diff-4cf5660e3c535a735b6953d578a91b9ce1dd14b064f584d2f3e58cd3264627dbR65-R67)